### PR TITLE
Move color palettes img examples to their own line

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repository contains resources for the Bitwarden brand such as logos, icons,
 
 ### Branding
 
-Bitwarden Blue
+Bitwarden Blue  
 ![Bitwarden Blue](/brand-colors/bitwarden-blue.png "Bitwarden Blue")   
  `#175DDC`
  
@@ -54,7 +54,7 @@ Indigo Blue
 ![Bitwarden Secondary Dark Blue](/brand-colors/indigo-blue.png "Bitwarden Indigo Blue")      
 `#020F66`
 
-Highlight Teal 
+Highlight Teal  
 ![Bitwarden Accent Green](/brand-colors/highlight-teal.png "Bitwarden Highlight Teal")      
 `#2CDDE9`
 


### PR DESCRIPTION
Some of the color palettes examples had the formatting:
```
Name
[Img]
Color
```

but some had:
```
Name[Img]
Color
```
When looking at the rendered README at Github (not the raw format)
By adding two spaces after the name, all of the examples look the same in the rendered form and is easier to read.